### PR TITLE
1. Add uploads. Queue them to optimize bandwidth.

### DIFF
--- a/src/services/upload-impl.ts
+++ b/src/services/upload-impl.ts
@@ -38,7 +38,7 @@ export function promiseOfUploadOfFile({ file }: FileUploadRequest) {
     })
       // Wait until the entire response is recieved
       // (Otherwise the promise resolves when only the headers have arrived)
-      // .then((resp) => resp.text())
+      .then((resp) => resp.text())
       // Simulate the one-at-the-end notification
       .then(() => ({ name: file.name, total: 100, loaded: 100 }))
   );

--- a/src/services/upload-service.ts
+++ b/src/services/upload-service.ts
@@ -1,11 +1,12 @@
-import { FileUploadRequest } from "../types";
+import { createQueueingService, createService } from "@rxfx/service";
+
+import { FileUploadRequest, UploadProgress } from "../types";
+import { bus } from "./bus";
 import { promiseOfUploadOfFile } from "./upload-impl";
 
-export const uploadService = {
-  request(req: FileUploadRequest) {
-    promiseOfUploadOfFile(req);
-  },
-  cancel() {
-    console.log("TODO handle upload/cancel");
-  },
-};
+/* prettier-ignore */
+export const uploadService = createQueueingService<FileUploadRequest, UploadProgress, Error>(
+  "upload",               // A namespace for events: upload/request
+  bus,                    // The bus our listener will be on
+  promiseOfUploadOfFile   // The effect-determining function
+);

--- a/src/services/upload-service.ts
+++ b/src/services/upload-service.ts
@@ -1,8 +1,9 @@
 import { FileUploadRequest } from "../types";
+import { promiseOfUploadOfFile } from "./upload-impl";
 
 export const uploadService = {
   request(req: FileUploadRequest) {
-    console.log("TODO handle upload/request", req);
+    promiseOfUploadOfFile(req);
   },
   cancel() {
     console.log("TODO handle upload/cancel");

--- a/src/ui/Chooser.tsx
+++ b/src/ui/Chooser.tsx
@@ -22,8 +22,6 @@ export const Chooser = () => {
   };
 
   const handleUploadClicked = () => {
-    console.log("TODO handle chooser/upload/click");
-
     uploadService.request(chosenFile);
 
     // Clear our state

--- a/src/ui/Chooser.tsx
+++ b/src/ui/Chooser.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { FileUploadRequest } from "../types";
 import { ONE_WEEK } from "./Chooser.mocks";
+import { uploadService } from "../services/upload-service";
 
 const { useState } = React;
 
@@ -22,6 +23,8 @@ export const Chooser = () => {
 
   const handleUploadClicked = () => {
     console.log("TODO handle chooser/upload/click");
+
+    uploadService.request(chosenFile);
 
     // Clear our state
     setChosenFile({});


### PR DESCRIPTION
With just a Promise-based uploader, and before we added queuing [Screenshot](#before-adding-queueing), uploads could proceed in parallel. By using RxFx, we easily select a mode, and the effects run queued, easily! [Screenshot](#after-adding-queueing)

<details>
<summary>Q: What NPM library did we use for queueing?</summary>
`@rxfx/service`
</details>

<details>
<summary>Q: How did we select that the uploads would proceed in a serial fashion?</summary>
We used **Queueing** mode, via `createQueueingService`
</details>

<details>
<summary>Q: What other modes are supplied?</summary>
Immediate - Switching - Blocking - Toggling
</details>

# Before adding queueing
![Before adding queueing](https://user-images.githubusercontent.com/24406/223453146-be81c789-e1ab-4c9b-86de-697862e750af.gif)

# After adding queueing
![After adding queueing](https://user-images.githubusercontent.com/24406/223453174-56bd9a78-cddb-45d8-9d0b-d18c487c21bb.gif)


