### PR TITLE
2. Capture progress events of an upload. Make an upload cancelable upon unmount.

### DIFF
--- a/src/services/bus.ts
+++ b/src/services/bus.ts
@@ -2,6 +2,7 @@ import { Bus } from "@rxfx/bus";
 import { Action } from "@rxfx/service";
 
 export const bus = new Bus<Action<any>>();
+Object.assign(window, { bus });
 
 /** Logs FSA bus events to the console - via `console.error` if their type contains 'error'.
  * @since 1.0.8

--- a/src/services/upload-service.ts
+++ b/src/services/upload-service.ts
@@ -2,11 +2,11 @@ import { createQueueingService, createService } from "@rxfx/service";
 
 import { FileUploadRequest, UploadProgress } from "../types";
 import { bus } from "./bus";
-import { promiseOfUploadOfFile } from "./upload-impl";
+import { observableOfUploadOfFile } from "./upload-impl";
 
 /* prettier-ignore */
 export const uploadService = createQueueingService<FileUploadRequest, UploadProgress, Error>(
-  "upload",               // A namespace for events: upload/request
-  bus,                    // The bus our listener will be on
-  promiseOfUploadOfFile   // The effect-determining function
+  "upload",                 // A namespace for events: upload/request
+  bus,                      // The bus our listener will be on
+  observableOfUploadOfFile  // The lazy, cancelable, and incremental effect
 );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,7 +6,7 @@ import { Chooser, Controls, Queue } from "./";
 export const App = () => {
   useWhileMounted(() => {
     // When unmounted, attempt to cancel
-    return () => uploadService.cancel();
+    return () => uploadService.cancelCurrent();
   });
 
   return (

--- a/src/ui/Chooser.tsx
+++ b/src/ui/Chooser.tsx
@@ -24,8 +24,6 @@ export const Chooser = () => {
   const handleUploadClicked = () => {
     uploadService.request(chosenFile);
 
-    uploadService.request(chosenFile);
-
     // Clear our state
     setChosenFile({});
   };

--- a/src/ui/Chooser.tsx
+++ b/src/ui/Chooser.tsx
@@ -24,6 +24,8 @@ export const Chooser = () => {
   const handleUploadClicked = () => {
     uploadService.request(chosenFile);
 
+    uploadService.request(chosenFile);
+
     // Clear our state
     setChosenFile({});
   };

--- a/src/ui/Controls.tsx
+++ b/src/ui/Controls.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
 
 import { EMPTY, ONE_PROGRESSING, ONE_QUEUED } from "./Queue.mocks";
+import { uploadService } from "../services/upload-service";
 
 export const Controls = () => {
-  const handleCancelCurrent = () => console.log("cancel current");
+  const handleCancelCurrent = () => {
+    uploadService.cancelCurrent();
+  };
   const handleCancelcurrentAndQueued = () => {
     console.log("cancel current and queued");
   };


### PR DESCRIPTION
With just a Promise-based uploader, the soonest we can update the UI is when fully uploaded. Provide progress events from the upload with RxJS' Ajax uploader. Note how this simple switch allows us to cancel by calling a method on the service. Progress Notifications and Cancelability are huge UX wins, particularly on mobile or bandwidth-constrained platforms.

<details>
<summary>Q: What allowed us to get increments of Progress? Why bother?</summary>
RxJS' ajax method returns an Observable of progress notifications - more like a stream than a function call with a single result. It was a simple drop-in replacement. 

The service displays all notifications from either its Promise or Observable handler - but you just get more notifications with the Observable, which is more informative to the user. A user gets more immediate feedback, so they don't believe the app is stalled. Further, they may decide to cancel if they see it's going too slowly.
</details>

<details>
<summary>Q: Why did we not require an AbortController?</summary>
The RxJS Ajax method returns an Observable, not a Promise - Every Observable in existence can be canceled (its subscription can be, to be precise) without any external object like an AbortController.
</details>

# Before Incremental Progress
![Before Incremental Progress](https://user-images.githubusercontent.com/24406/223458246-ced1d9c4-b80d-4807-a371-38808cea93ca.gif)

# After Incremental Progress
![RxFxUploaderWalkthrough-Step2 2 2](https://user-images.githubusercontent.com/24406/223458544-826f0756-f6f8-440a-ae4b-63889b64444d.gif)

# Before Cancelation
![RxFxUploaderWalkthrough-Step2 3](https://user-images.githubusercontent.com/24406/223460549-b1ec0b69-d906-401c-8436-a003f4f46ab6.gif)

# After Cancelation
![RxFxUploaderWalkthrough-Step2 4](https://user-images.githubusercontent.com/24406/223460565-4a33c1d3-800f-4d24-9398-7b6cb84dd217.gif)



