### PR TITLE
4. React to the number of completed uploads in UI state. Be unmount-friendly.

### DIFF
--- a/src/ui/Queue.tsx
+++ b/src/ui/Queue.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useService } from "@rxfx/react";
+import { useService, useWhileMounted } from "@rxfx/react";
 import { uploadService } from "../services/upload-service";
 import { EMPTY } from "./Queue.mocks";
 
@@ -9,7 +9,15 @@ export const Queue = () => {
   const { isActive } = useService(uploadService);
   const queue = EMPTY;
 
-  const [numCompleted] = useState(0);
+  const [numCompleted, setNumCompleted] = useState(0);
+
+  useWhileMounted(() => {
+    return uploadService.bus
+      .query(uploadService.actions.complete.match)
+      .subscribe(() => {
+        setNumCompleted((i: number) => i + 1);
+      });
+  });
 
   const icon = isActive ? "⏳" : "";
   const completedText = numCompleted ? `(${numCompleted} completed)` : "";


### PR DESCRIPTION
<details>
<summary>Q: Where did we provide our State type and reducer?</summary>
In the call to createService. Notably - outside of React's management or knowledge at all!
</details>

<details>
<summary>Q: How did we subscribe React to our service state? </summary>
In the call to `useWhileMounted`, we ran a query over the Event Bus for `upload/complete` events, incrementing our React state field upon every event. 
</details>

<details>
<summary>Q: What problems are avoided by using `useWhileMounted` to stay unmount-friendly?</summary>

Wrapping in useWhileMounted ensures we will never update the component once its been unmounted - the subscription returned from `bus.query.subscribe(...)` will be canceled before you can get the error about updating an unmounted component.
</details>

After tracking `upload/complete` events in state:
![RxFxUploaderWalkthrough-Step2 5](https://user-images.githubusercontent.com/24406/223462700-c3d99fd7-a2a5-4ec4-95da-36b6978900e8.gif)
